### PR TITLE
Updated link to Super Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Feel free to add links via PRs and file issues to start discussions.
 - [Vue.js author now works on it full time thanks to donations](https://twitter.com/vuejs/status/750560489462259712) by Evan You
 - [Fine Uploader attempted a FOSS-friendly commercial license](https://medium.com/@RayNicholus/disrupting-open-source-the-story-of-fine-uploader-80160eb557d9#.grwnuak60) by Ray Nicholus
 - [OptaPlanner gets picked up by Red Hat](http://www.optaplanner.org/blog/2016/08/07/ADecadeOfOptaPlanner.html) by Geoffrey De Smet
-- [Open Source Exploitation](http://supportedsource.org/blog/open-source-exploitation-and-burnout) by SupportedSource
+- [Open Source Exploitation](https://supso.org/blog/open-source-exploitation-and-burnout) by Super Source
 - [Redis author sponsored by Pivotal labs](http://antirez.com/news/91) by Antirez
 - [Charging for Open Source](http://www.mikeperham.com/2015/11/23/how-to-charge-for-your-open-source) by Mike Perham (author of Sidekiq)
 - [Corporations and OSS do not mix](http://www.coglib.com/~icordasc/blog/2015/11/corporations-and-oss-do-not-mix.html) by Ian Cordasco


### PR DESCRIPTION
Supported Source is now Super Source, so this updates the link.

It supports open source projects that don't sell licenses as well. What I mean is: open source projects can know who their users are by adding the Super Source library to their project, which will ask their users to register their use. Knowing who your users are is valuable if you ever want to do some sort of fundraising or ask for feedback.

I'm not sure whether you want to add anything about that use case to this git repo, but thought I'd share.