### PR TITLE
Fix Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Feel free to add links via PRs and file issues to start discussions.
 - [Phaser](http://phaser.io) (MIT) is [sponsored on Patreon](https://www.patreon.com/photonstorm).
 - [Brunch](http://brunch.io) (MIT) is sponsored by [Hell Yeah](http://hellyeah.is).
 - [NeoVim](https://github.com/neovim/neovim) (Apache 2.0) is sponsored by donations via [an ongoing BountySource campaign](https://www.bountysource.com/teams/neovim) and a [successful fundraising effort](https://www.bountysource.com/teams/neovim/fundraiser).
-- [Coala](https://github.com/coala-analyzer/coala) (AGPL v3.0) is sponsored by [Appveyor](https://www.appveyor.com).
+- [coala](https://github.com/coala/coala) (AGPL v3.0) is sponsored by [Appveyor](https://www.appveyor.com).
 
 ### Relevant Licenses
 


### PR DESCRIPTION
coala is always written with a small c.
Updated link to coala.