### PR TITLE
Add LibreSelery

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Feel free to add links via PRs and file issues to start discussions.
 - [Pulley](http://pulleyapp.com)
 - [Donorbox](https://donorbox.org)
 
+### Payment Tools
+- [LibreSelery](https://github.com/protontypes/libreselery)
+
 ### Profit-sharing Platforms
 
 - [BountySource Salt](https://salt.bountysource.com)


### PR DESCRIPTION
Right now we are the only Payment way that does not want to be a platform but a FOSS tool. That's why I created this new category.
LibreSelery works very well for LibreSelery funding itself and after going public 2 weeks ago we are now looking for further projects that want to adapt our approach. It would be nice to be part of this awesome list.
Find more information on our sources:
https://github.com/protontypes/libreselery

Our first blog post:
https://protontypes.eu/blog/2020/09/02/launch-of-protontypes/ 